### PR TITLE
Add movie csv

### DIFF
--- a/app/domain/repositories/movie_repository.py
+++ b/app/domain/repositories/movie_repository.py
@@ -1,6 +1,12 @@
-from typing import Dict
+from typing import Dict, List
 from abc import ABC, abstractmethod
+
+
 class MovieRepository(ABC):
     @abstractmethod
     def insert_movie(self, movie_dict: Dict) -> str:
+        pass
+
+    @abstractmethod
+    def insert_movies(self, movies_dict: List[Dict]) -> List[str]:
         pass

--- a/app/domain/repositories/movie_repository.py
+++ b/app/domain/repositories/movie_repository.py
@@ -8,5 +8,5 @@ class MovieRepository(ABC):
         pass
 
     @abstractmethod
-    def insert_movies(self, movies_dict: List[Dict]) -> List[str]:
+    def insert_many_movies(self, movies_dict: List[Dict]) -> List[str]:
         pass

--- a/app/domain/services/movie_services.py
+++ b/app/domain/services/movie_services.py
@@ -19,11 +19,11 @@ class MovieService:
 
             return message, 422
         
-    def add_movies(self, movies: List[Dict]) -> Tuple[str, int]:
+    def add_many_movies(self, movies: List[Dict]) -> Tuple[str, int]:
         try:
             movies_validated = [Movie(**movie) for movie in movies]
             movies_dict = [movie.model_dump(exclude={"id"}) for movie in movies_validated]
-            movies_ids = self._repository.insert_movies(movies_dict)
+            movies_ids = self._repository.insert_many_movies(movies_dict)
 
             return f"Movies created with IDs: {', '.join(movies_ids)}", 201
         except ValidationError as error:

--- a/app/domain/services/movie_services.py
+++ b/app/domain/services/movie_services.py
@@ -1,5 +1,5 @@
 from app.domain.models.movie import Movie
-from typing import Tuple, Dict
+from typing import List, Tuple, Dict
 from pydantic import ValidationError
 from app.domain.repositories.movie_repository import MovieRepository
 
@@ -14,6 +14,18 @@ class MovieService:
             movie_id = self._repository.insert_movie(movie_dict)
 
             return f"Movie created with ID: {movie_id}", 201
+        except ValidationError as error:
+            message = error.errors()[0].get("msg", "Invalid data")
+
+            return message, 422
+        
+    def add_movies(self, movies: List[Dict]) -> Tuple[str, int]:
+        try:
+            movies_validated = [Movie(**movie) for movie in movies]
+            movies_dict = [movie.model_dump(exclude={"id"}) for movie in movies_validated]
+            movies_ids = self._repository.insert_movies(movies_dict)
+
+            return f"Movies created with IDs: {', '.join(movies_ids)}", 201
         except ValidationError as error:
             message = error.errors()[0].get("msg", "Invalid data")
 

--- a/app/infrastructure/mongo_movie_repository.py
+++ b/app/infrastructure/mongo_movie_repository.py
@@ -7,6 +7,6 @@ class MongoMovieRepository(MovieRepository):
         movie_result = database.movies.insert_one(movie_dict)
         return str(movie_result.inserted_id)
     
-    def insert_movies(self, movies_dict: List[Dict]) -> List[str]:
+    def insert_many_movies(self, movies_dict: List[Dict]) -> List[str]:
         movies_identifiers = database.movies.insert_many(movies_dict)
         return [str(id) for id in movies_identifiers.inserted_ids]

--- a/app/infrastructure/mongo_movie_repository.py
+++ b/app/infrastructure/mongo_movie_repository.py
@@ -1,8 +1,12 @@
 from app.domain.repositories.movie_repository import MovieRepository
 from app.infrastructure.mongo_connection import database
-from typing import Dict
+from typing import Dict, List
 
 class MongoMovieRepository(MovieRepository):
     def insert_movie(self, movie_dict: Dict) -> str:
         movie_result = database.movies.insert_one(movie_dict)
         return str(movie_result.inserted_id)
+    
+    def insert_movies(self, movies_dict: List[Dict]) -> List[str]:
+        movies_identifiers = database.movies.insert_many(movies_dict)
+        return [str(id) for id in movies_identifiers.inserted_ids]

--- a/app/routes/movie_router.py
+++ b/app/routes/movie_router.py
@@ -7,9 +7,13 @@ from app.infrastructure.mongo_movie_repository import MongoMovieRepository
 movie_router = Blueprint('movies', __name__)
 
 @movie_router.route('/', methods=['POST'])
-def create_movie() -> Tuple[Response, int]:
+def create_movie() -> Tuple[Response, int] | Response:
         movie_service = MovieService(MongoMovieRepository())
         movie = request.get_json()
+
+        if isinstance(movie, list) or (isinstance(movie, dict) and len(movie) > 1):
+                return redirect(url_for('router.movies.create_movies'), code=307)
+
         response_message, status_code = movie_service.add_movie(movie)
         return jsonify({"message": response_message}), status_code
 
@@ -21,5 +25,5 @@ def create_movies() -> Tuple[Response, int] | Response:
         if isinstance(movies, dict) or (isinstance(movies, list) and len(movies) == 1):
                 return redirect(url_for('router.movies.create_movie'), code=307)
 
-        response_message, status_code = movie_service.add_movies(movies)
+        response_message, status_code = movie_service.add_many_movies(movies)
         return jsonify({"message": response_message}), status_code

--- a/app/routes/movie_router.py
+++ b/app/routes/movie_router.py
@@ -1,4 +1,5 @@
-from flask import Blueprint, request, Response, jsonify
+from flask import Blueprint, redirect, request, jsonify, url_for
+from werkzeug.wrappers.response import Response
 from typing import Tuple
 from app.domain.services.movie_services import MovieService
 from app.infrastructure.mongo_movie_repository import MongoMovieRepository
@@ -10,4 +11,15 @@ def create_movie() -> Tuple[Response, int]:
         movie_service = MovieService(MongoMovieRepository())
         movie = request.get_json()
         response_message, status_code = movie_service.add_movie(movie)
+        return jsonify({"message": response_message}), status_code
+
+@movie_router.route('/insert-many', methods=['POST'])
+def create_movies() -> Tuple[Response, int] | Response:
+        movie_service = MovieService(MongoMovieRepository())
+        movies = request.get_json()
+
+        if isinstance(movies, dict) or (isinstance(movies, list) and len(movies) == 1):
+                return redirect(url_for('router.movies.create_movie'), code=307)
+
+        response_message, status_code = movie_service.add_movies(movies)
         return jsonify({"message": response_message}), status_code

--- a/tests/features/add_movie_test.py
+++ b/tests/features/add_movie_test.py
@@ -3,7 +3,7 @@ def test_add_movie_success(client):
     payload = {
         "title": "Interstellar",
         "plot": "A team of explorers travel through a wormhole in space...",
-        "release_date": "2014-11-07",
+        "release_date": "2014",
         "genre": ["Sci-Fi", "Adventure"],
         "director": ["Christopher Nolan"],
         "rating": 4.9,
@@ -45,7 +45,7 @@ def test_add_movie_invalid_rating(client):
     payload = {
         "title": "Bad Rating",
         "plot": "Plot",
-        "release_date": "2014-11-07",
+        "release_date": "2014",
         "genre": "Drama",
         "director": "Someone",
         "rating": 6.0,  # Invalid rating > 5
@@ -65,7 +65,7 @@ def test_add_movie_invalid_poster_url(client):
     payload = {
         "title": "Bad Poster",
         "plot": "Plot",
-        "release_date": "2014-11-07",
+        "release_date": "2014",
         "genre": "Thriller",
         "director": "Someone",
         "rating": 4.5,
@@ -85,7 +85,7 @@ def test_add_movie_duplicate_genres_and_directors(client):
     payload = {
         "title": "Duplicated Fields",
         "plot": "Plot",
-        "release_date": "2020-01-01",
+        "release_date": "2020",
         "genre": ["Drama", "Drama", "Action"],
         "director": ["Nolan", "Nolan"],
         "rating": 3.5,

--- a/tests/features/add_movies_test.py
+++ b/tests/features/add_movies_test.py
@@ -1,0 +1,52 @@
+def test_add_movies_success(client):
+    # Arrange
+    payload = [
+        {
+            "title": "Inception",
+            "plot": "A thief who steals corporate secrets...",
+            "release_date": "2010",
+            "genre": ["Sci-Fi", "Thriller"],
+            "director": "Christopher Nolan",
+            "rating": 4.8,
+            "poster": "https://m.media-amazon.com/images/I/abc.jpg"
+        },
+        {
+            "title": "The Dark Knight",
+            "plot": "Batman raises the stakes in his war on crime...",
+            "release_date": "2008",
+            "genre": ["Action", "Crime"],
+            "director": "Christopher Nolan",
+            "rating": 4.9,
+            "poster": "https://m.media-amazon.com/images/I/def.jpg"
+        }
+    ]
+
+    # Act
+    response = client.post("/api/movies/insert-many", json=payload)
+
+    # Assert
+    assert response.status_code == 201
+    data = response.get_json()
+    assert "message" in data
+    assert "Movies created with IDs" in data["message"]
+
+def test_redirect_many_to_single_movie(client):
+    # Arrange
+    payload = [
+        {
+            "title": "Inception",
+            "plot": "A thief who steals corporate secrets...",
+            "release_date": "2010",
+            "genre": ["Sci-Fi", "Thriller"],
+            "director": "Christopher Nolan",
+            "rating": 4.8,
+            "poster": "https://m.media-amazon.com/images/I/abc.jpg"
+        }
+    ]
+
+    # Act
+    response = client.post("/api/movies/insert-many", json=payload)
+
+    # Assert
+    assert response.status_code == 307
+    assert response.headers["Location"].endswith("/api/movies/")

--- a/tests/features/add_movies_test.py
+++ b/tests/features/add_movies_test.py
@@ -1,4 +1,4 @@
-def test_add_movies_success(client):
+def test_add_many_movies_success(client):
     # Arrange
     payload = [
         {


### PR DESCRIPTION
# 📌 Pull Request

## ✨ ¿Qué se hizo?

Se agrega la funcionalidad de insertar varias películas en el endpoint de /movies/insert-many. Además, si a este endpoint se le envía una sola película se redirige la petición al endpoint /movies/ y viceversa.

## 🧪 ¿Cómo probar?

Envíar al endpoint varios objetos `Movie` dentro de una lista '[{},{}]'

## ✅ Checklist

- [x] El código funciona y pasa los tests.
- [x] La base de datos de test no afecta la base de datos real.
- [x] La validación de datos devuelve mensajes claros.
- [x] Agregué o actualicé tests.

## 🎯 Contexto adicional (opcional)

- Cambié el nombre de funciones para hacer más consistente el código.
