### PR TITLE
Get movies

### DIFF
--- a/app/domain/repositories/movie_repository.py
+++ b/app/domain/repositories/movie_repository.py
@@ -14,5 +14,9 @@ class MovieRepository(ABC):
         pass
 
     @abstractmethod
-    def get_all_movies(self) -> List[Movie]:
+    def get_all_movies(self, limit: int, offset: int) -> List[Movie]:
+        pass
+
+    @abstractmethod
+    def count_movies(self) -> int:
         pass

--- a/app/domain/services/movie_services.py
+++ b/app/domain/services/movie_services.py
@@ -31,7 +31,7 @@ class MovieService:
 
             return message, 422
     
-    def get_all_movies(self, limit: int = 10, offset: int = 0) -> List[Movie]:
+    def get_all_movies(self, limit: int, offset: int) -> List[Movie]:
         total_movies = self._repository.count_movies()
         if limit <= 0 or offset < 0 or offset >= total_movies:
             raise ValueError("Invalid pagination parameters")

--- a/app/domain/services/movie_services.py
+++ b/app/domain/services/movie_services.py
@@ -31,6 +31,9 @@ class MovieService:
 
             return message, 422
     
-    def get_all_movies(self) -> List[Movie]:
-        movies = self._repository.get_all_movies()
-        return movies          
+    def get_all_movies(self, limit: int = 10, offset: int = 0) -> List[Movie]:
+        total_movies = self._repository.count_movies()
+        if limit <= 0 or offset < 0 or offset >= total_movies:
+            raise ValueError("Invalid pagination parameters")
+        
+        return self._repository.get_all_movies(limit=limit, offset=offset)

--- a/app/infrastructure/mongo_movie_repository.py
+++ b/app/infrastructure/mongo_movie_repository.py
@@ -1,3 +1,4 @@
+from pymongo import ASCENDING
 from app.domain.models.movie import Movie
 from app.domain.repositories.movie_repository import MovieRepository
 from app.infrastructure.mongo_connection import database
@@ -11,7 +12,10 @@ class MongoMovieRepository(MovieRepository):
     def insert_many_movies(self, movies_dict: List[Dict]) -> List[str]:
         movies_identifiers = database.movies.insert_many(movies_dict)
         return [str(id) for id in movies_identifiers.inserted_ids]
-    
-    def get_all_movies(self) -> List[Movie]:
-        documents = database.movies.find()
+
+    def get_all_movies(self, limit: int, offset: int) -> List[Movie]:
+        documents = database.movies.find().sort("title", ASCENDING).skip(offset).limit(limit)
         return [Movie.from_mongo(document) for document in documents]
+    
+    def count_movies(self) -> int:
+        return database.movies.count_documents({})

--- a/app/routes/movie_router.py
+++ b/app/routes/movie_router.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, redirect, request, jsonify, url_for
 from werkzeug.wrappers.response import Response
 from typing import Tuple
+from app.domain.models.movie import Movie
 from app.domain.services.movie_services import MovieService
 from app.infrastructure.mongo_movie_repository import MongoMovieRepository
 

--- a/app/routes/movie_router.py
+++ b/app/routes/movie_router.py
@@ -50,7 +50,7 @@ def create_movies() -> Tuple[Response, int] | Response:
 def get_movies() -> Tuple[Response, int]:
         movie_service = MovieService(MongoMovieRepository())
         try:
-                movies_limit = request.args.get('limit', default=8, type=int)
+                movies_limit = request.args.get('limit', default=10, type=int)
                 movies_offset = request.args.get('offset', default=0, type=int)
 
                 movies_raw = movie_service.get_all_movies(limit=movies_limit, offset=movies_offset)

--- a/app/routes/movie_router.py
+++ b/app/routes/movie_router.py
@@ -6,6 +6,7 @@ from app.domain.services.movie_services import MovieService
 from app.infrastructure.mongo_movie_repository import MongoMovieRepository
 
 INTERNAL_SERVER_ERROR_MSG = "Internal server error"
+PAGINATION_ERROR_MSG = "Invalid pagination parameters"
 
 movie_router = Blueprint('movies', __name__)
 
@@ -49,8 +50,13 @@ def create_movies() -> Tuple[Response, int] | Response:
 def get_movies() -> Tuple[Response, int]:
         movie_service = MovieService(MongoMovieRepository())
         try:
-                movies_raw = movie_service.get_all_movies()
+                movies_limit = request.args.get('limit', default=8, type=int)
+                movies_offset = request.args.get('offset', default=0, type=int)
+
+                movies_raw = movie_service.get_all_movies(limit=movies_limit, offset=movies_offset)
                 movies = [movie.model_dump() for movie in movies_raw]
                 return jsonify(movies), 200
+        except ValueError:
+                return jsonify({"message": PAGINATION_ERROR_MSG}), 400
         except Exception:
                 return jsonify({"message": INTERNAL_SERVER_ERROR_MSG}), 500


### PR DESCRIPTION
# 📌 Pull Request

## ✨ ¿Qué se hizo?

- He realizado cambios en la funcionalidad de obtener todas las películas. Ahora la función get_all_movies tiene parametros de paginación, `limit` para limitar el número de películas a mostrar, `offset` la cantidad de salto en las primeras películas.
## 🧪 ¿Cómo probar?

- Usando el endpoint `GET /api/movies?limit=6&offset=2`

## ✅ Checklist

- [x] El código funciona.
- [ ] La base de datos de test no afecta la base de datos real.
- [x] La validación de datos devuelve mensajes claros.
- [ ] Agregué o actualicé tests.

## 🎯 Contexto adicional

- Además, se ordenan las películas por título ascendentemente
