### PR TITLE
Actualizar película 🧰

### DIFF
--- a/app/domain/models/movie_update.py
+++ b/app/domain/models/movie_update.py
@@ -1,0 +1,16 @@
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class MovieUpdate(BaseModel):
+    title: Optional[str] = Field(None, min_length=8)
+    plot: Optional[str] = Field(None, min_length=8)
+    director: Optional[str] = None
+    release_date: Optional[str] = None 
+    genre: Optional[List[str]] = None 
+    rating: Optional[float] = None
+    poster: Optional[str] = None
+
+    class Config:
+        extra = "forbid"

--- a/app/domain/repositories/movie_repository.py
+++ b/app/domain/repositories/movie_repository.py
@@ -26,3 +26,7 @@ class MovieRepository(ABC):
     @abstractmethod
     def get_movie_by_id(self, id: ObjectId) -> Movie | None:
         pass
+
+    @abstractmethod
+    def update_movie(self, id: ObjectId, movie_data: Dict) -> None:
+        pass

--- a/app/domain/services/movie_services.py
+++ b/app/domain/services/movie_services.py
@@ -2,6 +2,7 @@ from app.domain.models.movie import Movie
 from typing import List, Tuple, Dict
 from bson import ObjectId
 from pydantic import ValidationError
+from app.domain.models.movie_update import MovieUpdate
 from app.domain.repositories.movie_repository import MovieRepository
 
 class MovieService:
@@ -47,3 +48,18 @@ class MovieService:
 
     def get_movie_by_id(self, id: ObjectId) -> Movie | None:
         return self._repository.get_movie_by_id(id)
+
+    def update_movie(self, id: ObjectId, movie_data: Dict) -> Tuple[str, int]:
+        try:
+            movie_validated = MovieUpdate(**movie_data)
+
+            movie_dict = movie_validated.model_dump(exclude_unset=True)
+            
+            if not movie_dict:
+                return "No valid fields provided", 422
+
+            self._repository.update_movie(id, movie_dict)
+            return "Movie updated successfully", 200
+        except ValidationError as error:
+            message = error.errors()[0].get("msg", "Invalid data")
+            return message, 422

--- a/app/infrastructure/mongo_movie_repository.py
+++ b/app/infrastructure/mongo_movie_repository.py
@@ -52,3 +52,6 @@ class MongoMovieRepository(MovieRepository):
         if document:
             return Movie.from_mongo(document)
         return None
+    
+    def update_movie(self, id: ObjectId, movie_data: Dict) -> None:
+        database.movies.update_one({"_id": id}, {"$set": movie_data})

--- a/app/routes/movie_router.py
+++ b/app/routes/movie_router.py
@@ -87,3 +87,20 @@ def get_movie_by_id(id: str) -> Tuple[Response, int]:
                 return jsonify({"message": "Invalid movie ID"}), 400
         except Exception:
                 return jsonify({"message": INTERNAL_SERVER_ERROR_MSG}), 500
+
+@movie_router.route('/<id>', methods=['PATCH'])
+def update_movie(id: str) -> Tuple[Response, int]:
+        movie_service = MovieService(MongoMovieRepository())
+        
+        if not request.get_json():
+                return jsonify({"message": "No movie data provided"}), 422
+
+        movie_data = request.get_json()
+        try:
+                movie_id = ObjectId(id)
+                response_message, status_code = movie_service.update_movie(movie_id, movie_data)
+                return jsonify({"message": response_message}), status_code
+        except ValueError:
+                return jsonify({"message": "Invalid movie ID"}), 400
+        except Exception:
+                return jsonify({"message": INTERNAL_SERVER_ERROR_MSG}), 500


### PR DESCRIPTION
# 📌 Pull Request

## ✨ ¿Qué se hizo?

- Se implementó la actualización parcial de películas usando el método HTTP PATCH.
- Se protegió el campo id para que no pueda ser modificado por el cliente.
---
Se ajustó el servicio update_movie para:
- Aceptar y validar solo campos enviados `(exclude_unset=True)`.
- Retornar error si no se envían campos válidos.
- Se mantuvo la lógica en el repositorio Mongo para usar $set y actualizar solo los campos enviados

## 🧪 ¿Cómo probar?

- Ejecutar la API y asegurarse de tener una película insertada en la base de datos.
- Realizar una petición `PATCH` a `/api/movies/<id>` enviando solo uno o varios campos opcionales:

```bash
PATCH /movies/66bca3e7f9d71c2330a2452b
{
  "title": "The Matrix Reloaded"
}
```

## ✅ Checklist

 - [x] El código funciona y pasa los tests.
 - [x] La validación de datos devuelve mensajes claros.

## 🎯 Contexto adicional

- Este cambio resuelve la necesidad de actualizar películas parcialmente sin exigir que el cliente envíe todos los campos obligatorios del modelo `Movie`.
- Se creó un nuevo modelo `MovieUpdate` en `Pydantic` para validar datos opcionales y permitir actualizaciones flexibles.
